### PR TITLE
#226 북마크 전체보기 - 포스트 정보1개로 변경

### DIFF
--- a/src/apis/collection/bookmark.service.ts
+++ b/src/apis/collection/bookmark.service.ts
@@ -27,6 +27,7 @@ export class BookmarkService {
           컬렉션아이템에 정보가 등록되어 정보를 가져올 수 있음.
           북마크 생성만 하면 컬렉션아이템에 정보 등록이 안됨(생성을 수정해야 이슈해결)
     */
+
   async getBookmarks(userId: number) {
     try {
       const bookmarks = await this.collectionItemRepository.find({
@@ -58,20 +59,25 @@ export class BookmarkService {
         },
       });
 
-      const newBookmarks = bookmarks.map((item) => {
+      const groupedBookmarks = bookmarks.reduce((acc, item) => {
         const {
           collection: { id, name },
           post,
         } = item;
-        return {
-          id,
-          name,
-          image:
-            post?.images && post?.images?.length > 0
-              ? post?.images[0].file_url
-              : '',
-        };
-      });
+        if (!acc[id]) {
+          acc[id] = {
+            id,
+            name,
+            image:
+              post?.images && post?.images?.length > 0
+                ? post?.images[0].file_url
+                : '',
+          };
+        }
+        return acc;
+      }, {});
+
+      const newBookmarks = Object.values(groupedBookmarks);
 
       return newBookmarks;
     } catch (err) {


### PR DESCRIPTION
1개 컬렉션에 여러개의 포스트가 있으면 많은 정보를 가져오는데,
전체보기는 폴더를 보는 것처럼 1개의 이름과 이미지만 있으면 되기에
불러오는 정보를 1개로 제한